### PR TITLE
[SqlEndpoint] Force recreation when EnableServerlessCompute is modified

### DIFF
--- a/sql/resource_sql_endpoint.go
+++ b/sql/resource_sql_endpoint.go
@@ -29,7 +29,7 @@ type SQLEndpoint struct {
 	MaxNumClusters          int             `json:"max_num_clusters,omitempty" tf:"default:1"`
 	NumClusters             int             `json:"num_clusters,omitempty" tf:"suppress_diff"`
 	EnablePhoton            bool            `json:"enable_photon" tf:"optional,default:true"`
-	EnableServerlessCompute bool            `json:"enable_serverless_compute,omitempty" tf:"suppress_diff"`
+	EnableServerlessCompute bool            `json:"enable_serverless_compute,omitempty" tf:"suppress_diff,force_new"`
 	InstanceProfileARN      string          `json:"instance_profile_arn,omitempty"`
 	State                   string          `json:"state,omitempty" tf:"computed"`
 	JdbcURL                 string          `json:"jdbc_url,omitempty" tf:"computed"`


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Add flag `force_new` on parameter `EnableServerlessCompute`.
Modifying this parameter has no effect unless the Sql endpoint is recreated.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] relevant change in `docs/` folder
- [ ] covered with integration tests in `internal/acceptance`
- [ ] relevant acceptance tests are passing
- [ ] using Go SDK

